### PR TITLE
Add environment setup for jsdom tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ Thumbs.db
 .idea/
 *.swp
 *~
+
+# Node
+node_modules/
+package-lock.json

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   testEnvironment: 'jsdom',
-  roots: ['<rootDir>/tests']
+  roots: ['<rootDir>/tests'],
+  setupFiles: ['<rootDir>/tests/setup.js']
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^22.1.0"
   }
 }

--- a/script.js
+++ b/script.js
@@ -795,4 +795,16 @@ function toggleEditMode() {
             }
         });
     }
+
+    // Expose selected functions for testing
+    if (typeof window !== 'undefined') {
+        window.saveLocTest = {
+            setLocations: arr => { locations = arr; },
+            getLocations: () => locations,
+            loadLocations,
+            saveLocations,
+            showNotification,
+            exportToXml
+        };
+    }
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,7 @@
+const { TextEncoder, TextDecoder } = require('util');
+if (typeof global.TextEncoder === 'undefined') {
+  global.TextEncoder = TextEncoder;
+}
+if (typeof global.TextDecoder === 'undefined') {
+  global.TextDecoder = TextDecoder;
+}

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('UI elements', () => {
+  let document;
+  beforeAll(() => {
+    const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+    const dom = new JSDOM(html);
+    document = dom.window.document;
+  });
+
+  test('has Add Location button', () => {
+    expect(document.getElementById('addLocationBtn')).not.toBeNull();
+  });
+
+  test('drawer contains import elements', () => {
+    expect(document.getElementById('bottom-drawer')).not.toBeNull();
+    expect(document.getElementById('importXmlBtnTrigger')).not.toBeNull();
+    const input = document.getElementById('importXmlInput');
+    expect(input).not.toBeNull();
+    expect(input.getAttribute('type')).toBe('file');
+  });
+
+  test('links to manifest and script', () => {
+    const manifest = document.querySelector('link[rel="manifest"]');
+    expect(manifest).not.toBeNull();
+    const script = document.querySelector('script[src="script.js"]');
+    expect(script).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add node folders to gitignore
- include jest-environment-jsdom and setup file
- polyfill TextEncoder/Decoder for jsdom

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685115a0209c832fbc8087f28a505cbd