### PR TITLE
Add geolocation permission handling and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ python3 -m http.server
 
 Then browse to <http://localhost:8000>.
 
+## Location Permission
+
+SaveLoc needs access to your browser's Geolocation API when adding a location.
+On first use you will be asked to grant permission. If you accidentally deny the
+request, enable location access for the page in your browser settings.
+
 ## Import/export
 
 Use the menu to export all locations to an XML file or import from an existing file. Saved locations are stored in your browser's `localStorage` so they remain available on your device.

--- a/tests/domHelper.js
+++ b/tests/domHelper.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+module.exports = async function loadDom() {
+  let html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
+  html = html
+    .replace(/<link[^>]*unpkg[^>]*>/g, '')
+    .replace(/<script[^>]*unpkg[^>]*><\/script>/g, '')
+    .replace(/<script[^>]*src="script.js"[^>]*><\/script>/, '')
+    .replace(/<link[^>]*href="style.css"[^>]*>/, '');
+  const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
+
+  // Remove external styles/scripts to avoid network access
+  dom.window.document.querySelectorAll('link[rel="stylesheet"]').forEach(el => {
+    if (el.href.startsWith('http')) el.remove();
+  });
+  dom.window.document.querySelectorAll('script[src]').forEach(el => {
+    if (el.src.startsWith('http')) el.remove();
+  });
+
+  dom.window.console.log = () => {};
+  dom.window.console.error = () => {};
+
+  dom.window.navigator.geolocation = {
+    getCurrentPosition: (success, error) => {
+      if (success) success({ coords: { latitude: 0, longitude: 0 } });
+    }
+  };
+
+  dom.window.setTimeout = fn => { fn(); return 0; };
+  dom.window.setInterval = () => 0;
+
+  // Minimal Leaflet stub so script.js can run
+  dom.window.L = {
+    map: () => ({ setView: () => {}, on: () => {}, addLayer: () => {},
+      remove: () => {}, fitBounds: () => {} }),
+    tileLayer: () => ({ addTo: () => {} }),
+    divIcon: () => ({}),
+    layerGroup: () => ({ addTo: () => ({ clearLayers: () => {} }) }),
+    control: { layers: () => ({ addTo: () => {} }) },
+    marker: () => ({
+      addTo: () => ({ on: () => {}, setPopupContent: () => {}, openPopup: () => {}, isPopupOpen: () => false, locationId: '', dragging: { enabled: () => false, disable: () => {} } }),
+      on: () => {},
+      setPopupContent: () => {},
+      openPopup: () => {},
+      isPopupOpen: () => false,
+      locationId: '',
+      dragging: { enabled: () => false, disable: () => {} }
+    })
+  };
+
+  const scriptContent = fs.readFileSync(path.join(__dirname, '..', 'script.js'), 'utf8');
+  dom.window.eval(scriptContent);
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  await Promise.resolve();
+  return dom;
+};

--- a/tests/permission.test.js
+++ b/tests/permission.test.js
@@ -1,0 +1,29 @@
+const loadDom = require('./domHelper');
+
+let window, saveLocTest;
+
+beforeAll(async () => {
+  const dom = await loadDom();
+  window = dom.window;
+  saveLocTest = window.saveLocTest;
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('requestLocationPermission returns false when denied', async () => {
+  window.navigator.permissions = {
+    query: jest.fn().mockResolvedValue({ state: 'denied' })
+  };
+  const result = await saveLocTest.requestLocationPermission();
+  expect(result).toBe(false);
+});
+
+test('requestLocationPermission resolves when granted', async () => {
+  window.navigator.permissions = {
+    query: jest.fn().mockResolvedValue({ state: 'granted' })
+  };
+  const result = await saveLocTest.requestLocationPermission();
+  expect(result).toBe(true);
+});

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -1,0 +1,29 @@
+const loadDom = require('./domHelper');
+
+let window, saveLocTest;
+
+beforeAll(async () => {
+  const dom = await loadDom();
+  window = dom.window;
+  saveLocTest = window.saveLocTest;
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  saveLocTest.setLocations([]);
+});
+
+test('saveLocations stores data to localStorage', () => {
+  const data = [{ id: '1', lat: 1, lng: 2, label: 'A' }];
+  saveLocTest.setLocations(data);
+  saveLocTest.saveLocations();
+  const stored = JSON.parse(window.localStorage.getItem('savedLocations'));
+  expect(stored).toEqual(data);
+});
+
+test('loadLocations reads data from localStorage', () => {
+  const data = [{ id: '2', lat: 3, lng: 4, label: 'B' }];
+  window.localStorage.setItem('savedLocations', JSON.stringify(data));
+  saveLocTest.loadLocations();
+  expect(saveLocTest.getLocations()).toEqual(data);
+});


### PR DESCRIPTION
## Summary
- handle geolocation permission with new function `requestLocationPermission`
- invoke permission request on load
- expose function for tests via `saveLocTest`
- add tests for storage and permission logic with DOM helper
- document permission requirements in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511964b6e4832faf39b6b060347256