### PR TITLE
Add import XML tests

### DIFF
--- a/tests/domHelper.js
+++ b/tests/domHelper.js
@@ -30,6 +30,8 @@ module.exports = async function loadDom() {
 
   dom.window.setTimeout = fn => { fn(); return 0; };
   dom.window.setInterval = () => 0;
+  // jsdom does not provide setImmediate by default
+  dom.window.setImmediate = fn => setImmediate(fn);
 
   // Minimal Leaflet stub so script.js can run
   dom.window.L = {

--- a/tests/import.test.js
+++ b/tests/import.test.js
@@ -1,0 +1,45 @@
+const loadDom = require('./domHelper');
+
+let window, document, saveLocTest, importInput;
+
+beforeAll(async () => {
+  const dom = await loadDom();
+  window = dom.window;
+  document = window.document;
+  saveLocTest = window.saveLocTest;
+  importInput = document.getElementById('importXmlInput');
+  if (!window.setImmediate) {
+    window.setImmediate = setImmediate;
+  }
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  saveLocTest.setLocations([]);
+});
+
+function createFile(content) {
+  return new window.File([content], 'import.xml', { type: 'application/xml' });
+}
+
+test('handleFileImport imports XML file', async () => {
+  const xml = `<?xml version="1.0"?><root><plaatsen><id>1</id><lat>10</lat><lng>20</lng><label>Home</label></plaatsen></root>`;
+  Object.defineProperty(importInput, 'files', { value: [createFile(xml)], configurable: true });
+  importInput.dispatchEvent(new window.Event('change'));
+  await new Promise(res => setTimeout(res, 50));
+  expect(saveLocTest.getLocations().length).toBe(1);
+  const loc = saveLocTest.getLocations()[0];
+  expect(loc.lat).toBe(10);
+  expect(loc.lng).toBe(20);
+  expect(loc.label).toBe('Home');
+});
+
+test('handleFileImport ignores invalid XML', async () => {
+  const xml = `<root><plaatsen><id>1</id><lat>10</lat></root>`; // missing elements
+  Object.defineProperty(importInput, 'files', { value: [createFile(xml)], configurable: true });
+  importInput.dispatchEvent(new window.Event('change'));
+  await new Promise(res => setTimeout(res, 50));
+  expect(saveLocTest.getLocations().length).toBe(0);
+  const stored = window.localStorage.getItem('savedLocations');
+  expect(stored).toBeNull();
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,7 +1,11 @@
 const { TextEncoder, TextDecoder } = require('util');
+const timers = require('timers');
 if (typeof global.TextEncoder === 'undefined') {
   global.TextEncoder = TextEncoder;
 }
 if (typeof global.TextDecoder === 'undefined') {
   global.TextDecoder = TextDecoder;
+}
+if (typeof global.setImmediate === 'undefined') {
+  global.setImmediate = timers.setImmediate;
 }


### PR DESCRIPTION
## Summary
- polyfill `setImmediate` in DOM helper for FileReader support
- polyfill `setImmediate` globally for Jest tests
- add tests covering XML import handling

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685136bba614832fb5416193abe63e77