### PR TITLE
Add edit mode test coverage

### DIFF
--- a/tests/editMode.test.js
+++ b/tests/editMode.test.js
@@ -1,0 +1,27 @@
+const loadDom = require('./domHelper');
+
+let window, document, saveLocTest;
+
+beforeAll(async () => {
+  const dom = await loadDom();
+  window = dom.window;
+  document = window.document;
+  saveLocTest = window.saveLocTest;
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  saveLocTest.setLocations([]);
+});
+
+test('toggleEditMode updates button text', () => {
+  const btn = document.getElementById('editModeBtn');
+
+  expect(btn.textContent).toContain('Edit');
+
+  btn.click();
+  expect(btn.textContent).toContain('Exit');
+
+  btn.click();
+  expect(btn.textContent).toContain('Enter');
+});


### PR DESCRIPTION
## Summary
- improve Leaflet stub in domHelper
- add test for edit mode toggle functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68513bd8e490832f83f68445547cde88