### PR TITLE
Fix drawer closing behavior and add tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -20,6 +20,7 @@
 
     const hamburgerBtn = document.getElementById('hamburgerBtn');
     const bottomDrawer = document.getElementById('bottom-drawer');
+    const closeDrawerBtn = document.getElementById('closeDrawerBtn');
     const editModeBtn = document.getElementById('editModeBtn');
     const drawerContent = document.getElementById('drawer-main-content');
     const editFormDrawerSection = document.getElementById('edit-form-drawer-section');
@@ -71,6 +72,13 @@
     function toggleDrawer() {
       if (!bottomDrawer) return;
       bottomDrawer.classList.toggle('visible');
+      if (state.map) setTimeout(() => state.map.invalidateSize(), 300);
+    }
+
+    function closeDrawer() {
+      if (!bottomDrawer) return;
+      bottomDrawer.classList.remove('visible');
+      hideEditForm();
       if (state.map) setTimeout(() => state.map.invalidateSize(), 300);
     }
 
@@ -257,6 +265,7 @@
     if (exportXmlBtn) exportXmlBtn.addEventListener('click', exportToXml);
     if (addLocationBtn) addLocationBtn.addEventListener('click', handleAddLocationClick);
     if (hamburgerBtn) hamburgerBtn.addEventListener('click', toggleDrawer);
+    if (closeDrawerBtn) closeDrawerBtn.addEventListener('click', closeDrawer);
     if (editModeBtn) editModeBtn.addEventListener('click', toggleEditMode);
     if (saveLocationDrawerBtn) saveLocationDrawerBtn.addEventListener('click', saveEditedLocation);
     if (cancelEditDrawerBtn) cancelEditDrawerBtn.addEventListener('click', hideEditForm);
@@ -265,6 +274,10 @@
       importXmlBtnTrigger.addEventListener('click', () => importXmlInput.click());
       importXmlInput.addEventListener('change', handleFileImport);
     }
+
+    document.addEventListener('keydown', e => {
+      if (e.key === 'Escape') closeDrawer();
+    });
 
     storage.loadLocations();
     mapModule.setMarkerClickHandler(showEditForm);

--- a/tests/drawer.test.js
+++ b/tests/drawer.test.js
@@ -1,0 +1,33 @@
+const loadDom = require('./domHelper');
+
+let window, document;
+
+beforeAll(async () => {
+  const dom = await loadDom();
+  window = dom.window;
+  document = window.document;
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test('drawer closes with button and Escape key', () => {
+  const hamburger = document.getElementById('hamburgerBtn');
+  const closeBtn = document.getElementById('closeDrawerBtn');
+  const drawer = document.getElementById('bottom-drawer');
+
+  hamburger.click();
+  expect(drawer.classList.contains('visible')).toBe(true);
+
+  closeBtn.click();
+  expect(drawer.classList.contains('visible')).toBe(false);
+
+  hamburger.click();
+  expect(drawer.classList.contains('visible')).toBe(true);
+
+  const esc = new window.KeyboardEvent('keydown', { key: 'Escape' });
+  document.dispatchEvent(esc);
+  expect(drawer.classList.contains('visible')).toBe(false);
+});

--- a/tests/editMode.test.js
+++ b/tests/editMode.test.js
@@ -7,6 +7,7 @@ beforeAll(async () => {
   window = dom.window;
   document = window.document;
   saveLocTest = window.saveLocTest;
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- allow closing the menu drawer via X button and Escape key
- test drawer closing and edit mode toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852679bddd8832f92ca3a6cca3b18b6