### PR TITLE
Improve keyboard accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ request, enable location access for the page in your browser settings.
 
 Use the menu to export all locations to an XML file or import from an existing file. Saved locations are stored in your browser's `localStorage` so they remain available on your device.
 
+## Accessibility
+
+The application supports keyboard navigation. When forms or the drawer open, focus moves to the first input so screen reader users know where to start. You can reposition markers without using a mouse by editing the latitude and longitude fields in the edit drawer; changes update the marker on the map immediately.
+
 ## Running tests
 
 After installing dependencies run:

--- a/index.html
+++ b/index.html
@@ -51,12 +51,12 @@
                     <input type="text" id="editLocationLabelDrawer" placeholder="E.g., Home, Work">
                 </div>
                 <div>
-                    <label for="editLocationLatDrawer">Latitude:</label>
-                    <input type="text" id="editLocationLatDrawer" readonly>
+                <label for="editLocationLatDrawer">Latitude:</label>
+                <input type="number" id="editLocationLatDrawer" step="0.000001">
                 </div>
                 <div>
-                    <label for="editLocationLngDrawer">Longitude:</label>
-                    <input type="text" id="editLocationLngDrawer" readonly>
+                <label for="editLocationLngDrawer">Longitude:</label>
+                <input type="number" id="editLocationLngDrawer" step="0.000001">
                 </div>
                 <div class="form-buttons-container">
                     <button type="button" id="updateLocationToCurrentBtn" class="btn btn-update">🎯 Update to Current</button>
@@ -78,11 +78,11 @@
             </div>
             <div>
                 <label for="locationLat">Latitude:</label>
-                <input type="text" id="locationLat" readonly>
+                <input type="number" id="locationLat" step="0.000001">
             </div>
             <div>
                 <label for="locationLng">Longitude:</label>
-                <input type="text" id="locationLng" readonly>
+                <input type="number" id="locationLng" step="0.000001">
             </div>
             <div class="form-buttons-container">
                 <button type="button" id="saveLocationBtn" class="btn btn-primary">Save Location</button>

--- a/src/map.js
+++ b/src/map.js
@@ -85,6 +85,13 @@
     markerClickHandler = fn;
   }
 
-  return { loadMap, initMap, createLabelIcon, renderLocationsList, setMarkerClickHandler };
+  function updateMarkerPosition(id, lat, lng) {
+    const marker = state.markers[id];
+    if (marker) {
+      marker.setLatLng({ lat, lng });
+    }
+  }
+
+  return { loadMap, initMap, createLabelIcon, renderLocationsList, setMarkerClickHandler, updateMarkerPosition };
 }));
 

--- a/tests/accessibility.test.js
+++ b/tests/accessibility.test.js
@@ -1,0 +1,43 @@
+const loadDom = require('./domHelper');
+
+let window, document, saveLocTest;
+
+beforeAll(async () => {
+  const dom = await loadDom();
+  window = dom.window;
+  document = window.document;
+  saveLocTest = window.saveLocTest;
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  saveLocTest.setLocations([]);
+});
+
+test('focus moves to label when add form opens and returns on close', () => {
+  const trigger = document.getElementById('addLocationBtn');
+  trigger.focus();
+  saveLocTest.showAddForm();
+  expect(document.activeElement).toBe(document.getElementById('locationLabel'));
+  saveLocTest.hideAddForm();
+  expect(document.activeElement).toBe(trigger);
+});
+
+test('editing coordinate inputs updates marker position', () => {
+  const loc = { id: '1', lat: 1, lng: 2, label: 'A' };
+  saveLocTest.setLocations([loc]);
+  saveLocTest.renderLocationsList();
+  const marker = window.appState.markers['1'];
+  saveLocTest.showEditForm(loc);
+  const latInput = document.getElementById('editLocationLatDrawer');
+  const lngInput = document.getElementById('editLocationLngDrawer');
+  latInput.value = '3';
+  lngInput.value = '4';
+  latInput.dispatchEvent(new window.Event('input'));
+  lngInput.dispatchEvent(new window.Event('input'));
+  const pos = marker.getLatLng();
+  expect(pos.lat).toBe(3);
+  expect(pos.lng).toBe(4);
+  saveLocTest.hideEditForm();
+});


### PR DESCRIPTION
## Summary
- allow editing coordinates in the add and edit forms
- keep focus inside forms and drawer when opened
- expose helper functions for tests and update exports
- update map module with updateMarkerPosition helper
- add automated tests for accessibility helpers
- document keyboard navigation in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68527f1cf1e4832faa70267b317f4e26