### PR TITLE
Improve storage error handling

### DIFF
--- a/src/storage.js
+++ b/src/storage.js
@@ -8,11 +8,27 @@
   const STORAGE_KEY = 'savedLocations';
 
   function loadLocations() {
-    state.locations = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    state.locations = [];
+    try {
+      if (typeof localStorage === 'undefined') return;
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        state.locations = parsed.filter(item => item && typeof item === 'object');
+      }
+    } catch (e) {
+      // Leave locations empty when storage is inaccessible or corrupted
+    }
   }
 
   function saveLocations() {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.locations));
+    try {
+      if (typeof localStorage === 'undefined') return;
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state.locations));
+    } catch (e) {
+      // Ignore storage errors (e.g., quota exceeded, unavailable)
+    }
   }
 
   return { loadLocations, saveLocations, STORAGE_KEY };

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -27,3 +27,25 @@ test('loadLocations reads data from localStorage', () => {
   saveLocTest.loadLocations();
   expect(saveLocTest.getLocations()).toEqual(data);
 });
+
+test('loadLocations ignores invalid JSON', () => {
+  window.localStorage.setItem('savedLocations', 'not-json');
+  expect(() => saveLocTest.loadLocations()).not.toThrow();
+  expect(saveLocTest.getLocations()).toEqual([]);
+});
+
+test('loadLocations handles localStorage errors gracefully', () => {
+  const originalGet = window.localStorage.getItem;
+  window.localStorage.getItem = jest.fn(() => { throw new Error('fail'); });
+  expect(() => saveLocTest.loadLocations()).not.toThrow();
+  expect(saveLocTest.getLocations()).toEqual([]);
+  window.localStorage.getItem = originalGet;
+});
+
+test('saveLocations handles localStorage errors gracefully', () => {
+  const originalSet = window.localStorage.setItem;
+  window.localStorage.setItem = jest.fn(() => { throw new Error('fail'); });
+  saveLocTest.setLocations([{ id: '3', lat: 5, lng: 6, label: 'C' }]);
+  expect(() => saveLocTest.saveLocations()).not.toThrow();
+  window.localStorage.setItem = originalSet;
+});


### PR DESCRIPTION
## Summary
- handle localStorage read/write errors with try/catch
- validate parsed data before loading into state
- test error cases for storage module

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68527f5c0934832fa2970f8d8ceb881b