### PR TITLE
Add offline support via service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ request, enable location access for the page in your browser settings.
 
 Use the menu to export all locations to an XML file or import from an existing file. Saved locations are stored in your browser's `localStorage` so they remain available on your device.
 
+## Offline support
+
+The app registers a service worker that caches the main page, scripts, styles and map tiles. Once loaded, you can revisit the page without a network connection and previously viewed map areas will remain available.
+
 ## Accessibility
 
 The application supports keyboard navigation. When forms or the drawer open, focus moves to the first input so screen reader users know where to start. You can reposition markers without using a mouse by editing the latitude and longitude fields in the edit drawer; changes update the marker on the map immediately.

--- a/index.html
+++ b/index.html
@@ -109,5 +109,12 @@
     <script src="src/data-layer.js"></script>
     <script src="src/ui-controller.js"></script>
     <script src="main.js"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('service-worker.js');
+        });
+      }
+    </script>
   </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,61 @@
+const CACHE_NAME = 'saveloc-static-v1';
+const TILE_CACHE = 'saveloc-tiles-v1';
+const STATIC_ASSETS = [
+  './',
+  './index.html',
+  './style.css',
+  './main.js',
+  './manifest.json',
+  './icons/icon-192x192.svg',
+  './icons/icon-512x512.svg',
+  './src/state.js',
+  './src/ui.js',
+  './src/storage.js',
+  './src/permission.js',
+  './src/map.js',
+  './src/data-layer.js',
+  './src/ui-controller.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => {
+      return Promise.all(
+        keys.filter(k => k !== CACHE_NAME && k !== TILE_CACHE).map(k => caches.delete(k))
+      );
+    })
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+
+  if (url.hostname.match(/(tile\.openstreetmap\.org|basemaps\.cartocdn\.com|arcgisonline\.com)/)) {
+    event.respondWith(
+      caches.open(TILE_CACHE).then(cache => {
+        return cache.match(event.request).then(response => {
+          const fetchPromise = fetch(event.request).then(networkResp => {
+            cache.put(event.request, networkResp.clone());
+            return networkResp;
+          });
+          return response || fetchPromise;
+        });
+      })
+    );
+    return;
+  }
+
+  if (event.request.method === 'GET' && url.origin === location.origin) {
+    event.respondWith(
+      caches.match(event.request).then(resp => resp || fetch(event.request))
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- register a service worker in `index.html`
- add caching service worker to support offline usage
- document offline capability in README

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68528667311c832fb0e808a363e47393