### PR TITLE
Close drawer after saving or cancelling edits

### DIFF
--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -143,7 +143,7 @@ import { requestLocationPermission } from "./permission.mjs";
       storage.saveLocations();
       mapModule.renderLocationsList();
     }
-    hideEditForm();
+    closeDrawer();
   }
 
   function updateEditLocationToCurrent() {
@@ -319,7 +319,7 @@ import { requestLocationPermission } from "./permission.mjs";
     if (closeDrawerBtn) closeDrawerBtn.addEventListener('click', closeDrawer);
     if (editModeBtn) editModeBtn.addEventListener('click', toggleEditMode);
     if (saveLocationDrawerBtn) saveLocationDrawerBtn.addEventListener('click', saveEditedLocation);
-    if (cancelEditDrawerBtn) cancelEditDrawerBtn.addEventListener('click', hideEditForm);
+    if (cancelEditDrawerBtn) cancelEditDrawerBtn.addEventListener('click', closeDrawer);
     if (updateLocationToCurrentBtn) updateLocationToCurrentBtn.addEventListener('click', updateEditLocationToCurrent);
     if (editLocationLatDrawer) editLocationLatDrawer.addEventListener('input', handleCoordinateInput);
     if (editLocationLngDrawer) editLocationLngDrawer.addEventListener('input', handleCoordinateInput);

--- a/tests/drawer.actions.test.js
+++ b/tests/drawer.actions.test.js
@@ -1,0 +1,39 @@
+const loadDom = require('./domHelper');
+
+let window, document, saveLocTest;
+
+beforeAll(async () => {
+  const dom = await loadDom();
+  window = dom.window;
+  document = window.document;
+  saveLocTest = window.saveLocTest;
+  document.dispatchEvent(new window.Event('DOMContentLoaded'));
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  saveLocTest.setLocations([]);
+});
+
+test('saving edits closes the drawer', () => {
+  const loc = { id: '1', lat: 1, lng: 2, label: 'A' };
+  saveLocTest.setLocations([loc]);
+  saveLocTest.renderLocationsList();
+  saveLocTest.showEditForm(loc);
+  const drawer = document.getElementById('bottom-drawer');
+  expect(drawer.classList.contains('visible')).toBe(true);
+  document.getElementById('editLocationLabelDrawer').value = 'B';
+  document.getElementById('saveLocationDrawerBtn').click();
+  expect(drawer.classList.contains('visible')).toBe(false);
+});
+
+test('canceling edit closes the drawer', () => {
+  const loc = { id: '1', lat: 1, lng: 2, label: 'A' };
+  saveLocTest.setLocations([loc]);
+  saveLocTest.renderLocationsList();
+  saveLocTest.showEditForm(loc);
+  const drawer = document.getElementById('bottom-drawer');
+  expect(drawer.classList.contains('visible')).toBe(true);
+  document.getElementById('cancelEditDrawerBtn').click();
+  expect(drawer.classList.contains('visible')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- hide drawer when saving edits so map is visible again
- close drawer when cancelling edit form
- test drawer closes after saving or cancelling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ad3693ac832f9e0c832f277f7fc2