### PR TITLE
Close menu drawer after import/export

### DIFF
--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -203,6 +203,7 @@ import { requestLocationPermission } from "./permission.mjs";
   }
 
   function exportToXml() {
+    closeDrawer();
     if (appState.locations.length === 0) {
       showNotification('No locations to export.', 'info');
       return;
@@ -284,6 +285,7 @@ import { requestLocationPermission } from "./permission.mjs";
         showNotification('An error occurred while processing the XML file.', 'error');
       }
       event.target.value = null;
+      closeDrawer();
     };
     reader.onerror = function() {
       showNotification('Error reading file.', 'error');
@@ -324,7 +326,10 @@ import { requestLocationPermission } from "./permission.mjs";
     if (editLocationLatDrawer) editLocationLatDrawer.addEventListener('input', handleCoordinateInput);
     if (editLocationLngDrawer) editLocationLngDrawer.addEventListener('input', handleCoordinateInput);
     if (importXmlBtnTrigger && importXmlInput) {
-      importXmlBtnTrigger.addEventListener('click', () => importXmlInput.click());
+      importXmlBtnTrigger.addEventListener('click', () => {
+        closeDrawer();
+        importXmlInput.click();
+      });
       importXmlInput.addEventListener('change', handleFileImport);
     }
 

--- a/tests/drawer.actions.test.js
+++ b/tests/drawer.actions.test.js
@@ -37,3 +37,29 @@ test('canceling edit closes the drawer', () => {
   document.getElementById('cancelEditDrawerBtn').click();
   expect(drawer.classList.contains('visible')).toBe(false);
 });
+
+function createFile(content) {
+  return new window.File([content], 'import.xml', { type: 'application/xml' });
+}
+
+test('export action closes the drawer', () => {
+  saveLocTest.setLocations([{ id: '1', lat: 1, lng: 2, label: 'A' }]);
+  saveLocTest.toggleDrawer();
+  const drawer = document.getElementById('bottom-drawer');
+  expect(drawer.classList.contains('visible')).toBe(true);
+  window.URL.createObjectURL = jest.fn(() => 'blob:url');
+  window.URL.revokeObjectURL = jest.fn();
+  saveLocTest.exportToXml();
+  expect(drawer.classList.contains('visible')).toBe(false);
+});
+
+test('import action closes the drawer', async () => {
+  saveLocTest.toggleDrawer();
+  const drawer = document.getElementById('bottom-drawer');
+  expect(drawer.classList.contains('visible')).toBe(true);
+  const xml = `<?xml version="1.0"?><root><plaatsen><id>1</id><lat>10</lat><lng>20</lng><label>Home</label></plaatsen></root>`;
+  const event = { target: { files: [createFile(xml)] } };
+  saveLocTest.handleFileImport(event);
+  await new Promise(res => setTimeout(res, 50));
+  expect(drawer.classList.contains('visible')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- hide the drawer when exporting or importing locations
- test that import and export actions close the drawer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852b13f16d0832f9e5f121cd0f973f5