### PR TITLE
Add multilingual support (NL & DE)

### DIFF
--- a/docs/i18n.mjs
+++ b/docs/i18n.mjs
@@ -1,0 +1,161 @@
+export const translations = {
+  en: {
+    title: 'SaveLoc - Bookmark Locations',
+    add_location: 'Add Location',
+    add_location_title: 'Add new location (uses current GPS)',
+    edit_button: '✎ Edit',
+    enter_edit_mode: 'Enter Edit Mode',
+    exit_edit_mode: 'Exit Edit Mode',
+    menu: 'Menu',
+    close_menu: 'Close menu',
+    clear_all: 'Clear All Locations',
+    export_xml: 'Export as XML',
+    import_xml: 'Import XML',
+    saved_locations: 'Saved Locations',
+    no_locations: 'No locations saved yet.',
+    edit_location: 'Edit Location',
+    label: 'Label:',
+    label_placeholder: 'E.g., Home, Work',
+    latitude: 'Latitude:',
+    longitude: 'Longitude:',
+    update_to_current: '🎯 Update to Current',
+    save_changes: 'Save Changes',
+    cancel: 'Cancel',
+    add_new_location: 'Add New Location',
+    location_placeholder: 'E.g., Home, Work, Park Entrance',
+    save_location: 'Save Location',
+    fetching: 'Fetching...',
+    geolocation_unsupported: 'Geolocation is not supported by your browser',
+    error_getting_current: 'Error getting current location: {error}',
+    invalid_input: 'Invalid input',
+    no_locations_to_clear: 'There are no locations to clear.',
+    confirm_delete_all: 'Are you sure you want to delete ALL locations? This cannot be undone.',
+    no_locations_to_export: 'No locations to export.',
+    error_parsing_xml: 'Error parsing XML file. Please check the file format.',
+    no_locations_in_file: 'No locations found in the XML file.',
+    locations_imported: '{count} location(s) imported successfully.',
+    an_error_occurred: 'An error occurred while processing the XML file.',
+    error_reading_file: 'Error reading file.',
+    location_permission_denied: 'Location permission denied.',
+    location_permission_denied_enable: 'Location permission denied. Enable it in your browser settings.'
+  },
+  nl: {
+    title: 'SaveLoc - Locaties opslaan',
+    add_location: 'Locatie toevoegen',
+    add_location_title: 'Nieuwe locatie toevoegen (gebruikt GPS)',
+    edit_button: '✎ Bewerken',
+    enter_edit_mode: 'Bewerkmodus starten',
+    exit_edit_mode: 'Bewerkmodus verlaten',
+    menu: 'Menu',
+    close_menu: 'Menu sluiten',
+    clear_all: 'Alle locaties verwijderen',
+    export_xml: 'Exporteren als XML',
+    import_xml: 'XML importeren',
+    saved_locations: 'Opgeslagen locaties',
+    no_locations: 'Nog geen locaties opgeslagen.',
+    edit_location: 'Locatie bewerken',
+    label: 'Label:',
+    label_placeholder: 'Bijv. Thuis, Werk',
+    latitude: 'Breedtegraad:',
+    longitude: 'Lengtegraad:',
+    update_to_current: '🎯 Bijwerken naar huidige',
+    save_changes: 'Wijzigingen opslaan',
+    cancel: 'Annuleren',
+    add_new_location: 'Nieuwe locatie toevoegen',
+    location_placeholder: 'Bijv. Thuis, Werk, Park-ingang',
+    save_location: 'Locatie opslaan',
+    fetching: 'Bezig...',
+    geolocation_unsupported: 'Geolocatie wordt niet ondersteund door je browser',
+    error_getting_current: 'Fout bij ophalen huidige locatie: {error}',
+    invalid_input: 'Ongeldige invoer',
+    no_locations_to_clear: 'Er zijn geen locaties om te wissen.',
+    confirm_delete_all: 'Weet je zeker dat je ALLE locaties wilt verwijderen? Dit kan niet ongedaan worden.',
+    no_locations_to_export: 'Geen locaties om te exporteren.',
+    error_parsing_xml: 'Fout bij het lezen van het XML-bestand. Controleer het formaat.',
+    no_locations_in_file: 'Geen locaties gevonden in het XML-bestand.',
+    locations_imported: '{count} locatie(s) succesvol geïmporteerd.',
+    an_error_occurred: 'Er is een fout opgetreden bij het verwerken van het XML-bestand.',
+    error_reading_file: 'Fout bij het lezen van het bestand.',
+    location_permission_denied: 'Locatietoestemming geweigerd.',
+    location_permission_denied_enable: 'Locatietoestemming geweigerd. Schakel dit in je browser in.'
+  },
+  de: {
+    title: 'SaveLoc - Orte speichern',
+    add_location: 'Standort hinzufügen',
+    add_location_title: 'Neuen Standort hinzufügen (verwendet GPS)',
+    edit_button: '✎ Bearbeiten',
+    enter_edit_mode: 'Bearbeitungsmodus starten',
+    exit_edit_mode: 'Bearbeitungsmodus beenden',
+    menu: 'Menü',
+    close_menu: 'Menü schließen',
+    clear_all: 'Alle Standorte löschen',
+    export_xml: 'Als XML exportieren',
+    import_xml: 'XML importieren',
+    saved_locations: 'Gespeicherte Standorte',
+    no_locations: 'Noch keine Standorte gespeichert.',
+    edit_location: 'Standort bearbeiten',
+    label: 'Bezeichnung:',
+    label_placeholder: 'z.B. Zuhause, Arbeit',
+    latitude: 'Breitengrad:',
+    longitude: 'Längengrad:',
+    update_to_current: '🎯 Auf aktuelle aktualisieren',
+    save_changes: 'Änderungen speichern',
+    cancel: 'Abbrechen',
+    add_new_location: 'Neuen Standort hinzufügen',
+    location_placeholder: 'z.B. Zuhause, Arbeit, Parkeingang',
+    save_location: 'Standort speichern',
+    fetching: 'Lädt...',
+    geolocation_unsupported: 'Geolocation wird von deinem Browser nicht unterstützt',
+    error_getting_current: 'Fehler beim Abrufen des aktuellen Standorts: {error}',
+    invalid_input: 'Ungültige Eingabe',
+    no_locations_to_clear: 'Keine Standorte zum Löschen.',
+    confirm_delete_all: 'Möchtest du wirklich ALLE Standorte löschen? Dies kann nicht rückgängig gemacht werden.',
+    no_locations_to_export: 'Keine Standorte zum Exportieren.',
+    error_parsing_xml: 'Fehler beim Parsen der XML-Datei. Bitte Dateiformat prüfen.',
+    no_locations_in_file: 'Keine Standorte in der XML-Datei gefunden.',
+    locations_imported: '{count} Standort(e) erfolgreich importiert.',
+    an_error_occurred: 'Beim Verarbeiten der XML-Datei ist ein Fehler aufgetreten.',
+    error_reading_file: 'Fehler beim Lesen der Datei.',
+    location_permission_denied: 'Standortberechtigung verweigert.',
+    location_permission_denied_enable: 'Standortberechtigung verweigert. Aktiviere sie in deinen Browsereinstellungen.'
+  }
+};
+
+let currentLang = null;
+
+export function getUserLanguage() {
+  const langs = navigator.languages || [navigator.language || 'en'];
+  for (const lang of langs) {
+    const short = lang.toLowerCase().split('-')[0];
+    if (translations[short]) return short;
+  }
+  return 'en';
+}
+
+export function t(key, vars = {}) {
+  if (!currentLang) currentLang = getUserLanguage();
+  const str = (translations[currentLang] && translations[currentLang][key]) || translations.en[key] || key;
+  return str.replace(/\{(\w+)\}/g, (_, k) => vars[k] ?? `{${k}}`);
+}
+
+export function applyTranslations() {
+  currentLang = getUserLanguage();
+  document.documentElement.lang = currentLang;
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    el.textContent = t(key);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    const key = el.getAttribute('data-i18n-placeholder');
+    el.setAttribute('placeholder', t(key));
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach(el => {
+    const key = el.getAttribute('data-i18n-title');
+    el.setAttribute('title', t(key));
+  });
+  document.querySelectorAll('[data-i18n-aria-label]').forEach(el => {
+    const key = el.getAttribute('data-i18n-aria-label');
+    el.setAttribute('aria-label', t(key));
+  });
+}
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>SaveLoc - Bookmark Locations</title>
+    <title data-i18n="title">SaveLoc - Bookmark Locations</title>
     <link rel="stylesheet" href="vendor/leaflet.css">
     <link rel="stylesheet" href="style.css">
     <link rel="manifest" href="manifest.json">
@@ -12,56 +12,56 @@
 </head>
 <body>
     <div id="top-bar">
-        <button id="addLocationBtn" class="btn btn-primary" title="Add new location (uses current GPS)">Add Location</button>
-        <button id="editModeBtn" aria-label="Enter Edit Mode">✎ Edit</button>
+        <button id="addLocationBtn" class="btn btn-primary" title="Add new location (uses current GPS)" data-i18n="add_location" data-i18n-title="add_location_title">Add Location</button>
+        <button id="editModeBtn" aria-label="Enter Edit Mode" data-i18n="edit_button" data-i18n-aria-label="enter_edit_mode">✎ Edit</button>
         <div class="spacer"></div>
-        <button id="hamburgerBtn" aria-label="Menu">☰</button>
+        <button id="hamburgerBtn" aria-label="Menu" data-i18n-aria-label="menu">☰</button>
     </div>
 
     <div id="map"></div>
 
     <div id="bottom-drawer">
         <div class="drawer-header">
-            <h3>Menu</h3>
-            <button id="closeDrawerBtn" aria-label="Close menu">×</button>
+            <h3 data-i18n="menu">Menu</h3>
+            <button id="closeDrawerBtn" aria-label="Close menu" data-i18n-aria-label="close_menu">×</button>
         </div>
         <div class="drawer-content" id="drawer-main-content">
-            <button id="clearListBtn">Clear All Locations</button>
-            <button id="exportXmlBtn">Export as XML</button>
-            <button id="importXmlBtnTrigger">Import XML</button>
+            <button id="clearListBtn" data-i18n="clear_all">Clear All Locations</button>
+            <button id="exportXmlBtn" data-i18n="export_xml">Export as XML</button>
+            <button id="importXmlBtnTrigger" data-i18n="import_xml">Import XML</button>
             <input type="file" id="importXmlInput" accept=".xml" style="display: none;">
             
             <section id="locations-list-section-drawer">
-                <h4>Saved Locations</h4>
+                <h4 data-i18n="saved_locations">Saved Locations</h4>
                 <ul id="locationsList"></ul>
-                <div id="no-locations-message" class="hidden">No locations saved yet.</div>
+                <div id="no-locations-message" class="hidden" data-i18n="no_locations">No locations saved yet.</div>
             </section>
         </div>
 
         <!-- Edit Form Section within Drawer (hidden by default) -->
         <div id="edit-form-drawer-section" class="hidden">
             <div class="drawer-header">
-                <h3 id="edit-form-drawer-title">Edit Location</h3>
+                <h3 id="edit-form-drawer-title" data-i18n="edit_location">Edit Location</h3>
                 <!-- No close button here, use form's Cancel button -->
             </div>
             <div class="drawer-content">
                 <input type="hidden" id="editLocationIdDrawer">
                 <div>
-                    <label for="editLocationLabelDrawer">Label:</label>
-                    <input type="text" id="editLocationLabelDrawer" placeholder="E.g., Home, Work">
+                    <label for="editLocationLabelDrawer" data-i18n="label">Label:</label>
+                    <input type="text" id="editLocationLabelDrawer" data-i18n-placeholder="label_placeholder" placeholder="E.g., Home, Work">
                 </div>
                 <div>
-                <label for="editLocationLatDrawer">Latitude:</label>
+                <label for="editLocationLatDrawer" data-i18n="latitude">Latitude:</label>
                 <input type="number" id="editLocationLatDrawer" step="0.000001">
                 </div>
                 <div>
-                <label for="editLocationLngDrawer">Longitude:</label>
+                <label for="editLocationLngDrawer" data-i18n="longitude">Longitude:</label>
                 <input type="number" id="editLocationLngDrawer" step="0.000001">
                 </div>
                 <div class="form-buttons-container">
-                    <button type="button" id="updateLocationToCurrentBtn" class="btn btn-update">🎯 Update to Current</button>
-                    <button type="button" id="saveLocationDrawerBtn" class="btn btn-primary">Save Changes</button>
-                    <button type="button" id="cancelEditDrawerBtn" class="btn btn-secondary">Cancel</button>
+                    <button type="button" id="updateLocationToCurrentBtn" class="btn btn-update" data-i18n="update_to_current">🎯 Update to Current</button>
+                    <button type="button" id="saveLocationDrawerBtn" class="btn btn-primary" data-i18n="save_changes">Save Changes</button>
+                    <button type="button" id="cancelEditDrawerBtn" class="btn btn-secondary" data-i18n="cancel">Cancel</button>
                 </div>
             </div>
         </div>
@@ -70,23 +70,23 @@
     <!-- Location Form (modal) -->
     <section id="location-form-section" class="hidden">
         <div class="form-content">
-            <h2><span id="form-title">Add New</span> Location</h2>
+            <h2 id="add-form-title" data-i18n="add_new_location">Add New Location</h2>
             <input type="hidden" id="locationId">
             <div>
-                <label for="locationLabel">Label:</label>
-                <input type="text" id="locationLabel" placeholder="E.g., Home, Work, Park Entrance">
+                <label for="locationLabel" data-i18n="label">Label:</label>
+                <input type="text" id="locationLabel" data-i18n-placeholder="location_placeholder" placeholder="E.g., Home, Work, Park Entrance">
             </div>
             <div>
-                <label for="locationLat">Latitude:</label>
+                <label for="locationLat" data-i18n="latitude">Latitude:</label>
                 <input type="number" id="locationLat" step="0.000001">
             </div>
             <div>
-                <label for="locationLng">Longitude:</label>
+                <label for="locationLng" data-i18n="longitude">Longitude:</label>
                 <input type="number" id="locationLng" step="0.000001">
             </div>
             <div class="form-buttons-container">
-                <button type="button" id="saveLocationBtn" class="btn btn-primary">Save Location</button>
-                <button type="button" id="cancelFormBtn" class="btn btn-secondary">Cancel</button>
+                <button type="button" id="saveLocationBtn" class="btn btn-primary" data-i18n="save_location">Save Location</button>
+                <button type="button" id="cancelFormBtn" class="btn btn-secondary" data-i18n="cancel">Cancel</button>
             </div>
         </div>
     </section>

--- a/docs/main.mjs
+++ b/docs/main.mjs
@@ -1,9 +1,11 @@
 import uiController from './src/ui-controller.mjs';
+import { applyTranslations } from './i18n.mjs';
 
 // expose test API immediately so tests can access it before DOMContentLoaded
 window.saveLocTest = uiController.testApi;
 
 // run init once the DOM is fully loaded
 document.addEventListener('DOMContentLoaded', () => {
+  applyTranslations();
   uiController.init();
 });

--- a/docs/src/permission.mjs
+++ b/docs/src/permission.mjs
@@ -1,4 +1,5 @@
 import { showNotification } from './ui.mjs';
+import { t } from '../i18n.mjs';
 
 export async function requestLocationPermission() {
   if (!navigator.permissions || !navigator.permissions.query) {
@@ -11,11 +12,11 @@ export async function requestLocationPermission() {
       return new Promise(resolve => {
         navigator.geolocation.getCurrentPosition(
           () => resolve(true),
-          () => { showNotification('Location permission denied.', 'error'); resolve(false); }
+          () => { showNotification(t('location_permission_denied'), 'error'); resolve(false); }
         );
       });
     }
-    showNotification('Location permission denied. Enable it in your browser settings.', 'error');
+    showNotification(t('location_permission_denied_enable'), 'error');
     return false;
   } catch (e) {
     return true;

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -4,6 +4,7 @@ import * as storage from "./storage.mjs";
 import { showNotification } from "./ui.mjs";
 import * as mapModule from "./map.mjs";
 import { requestLocationPermission } from "./permission.mjs";
+import { t } from "../i18n.mjs";
 
   function showAddForm(data = {}) {
     const section = document.getElementById('location-form-section');
@@ -89,7 +90,9 @@ import { requestLocationPermission } from "./permission.mjs";
     appState.isInEditMode = !appState.isInEditMode;
     const editModeBtn = document.getElementById('editModeBtn');
     if (editModeBtn) {
-      editModeBtn.textContent = appState.isInEditMode ? 'Exit Edit Mode' : 'Enter Edit Mode';
+      const key = appState.isInEditMode ? 'exit_edit_mode' : 'enter_edit_mode';
+      editModeBtn.textContent = t(key);
+      editModeBtn.setAttribute('aria-label', t(key));
     }
     mapModule.renderLocationsList();
   }
@@ -98,12 +101,12 @@ import { requestLocationPermission } from "./permission.mjs";
     const addBtn = document.getElementById('addLocationBtn');
     if (!navigator.geolocation) {
       const nextLabel = (appState.locations.length + 1).toString();
-      showNotification('Geolocation is not supported by your browser', 'error');
+      showNotification(t('geolocation_unsupported'), 'error');
       showAddForm({ label: nextLabel });
       return;
     }
     addBtn.disabled = true;
-    addBtn.textContent = 'Fetching...';
+    addBtn.textContent = t('fetching');
     navigator.geolocation.getCurrentPosition(
       pos => {
         const nextLabel = (appState.locations.length + 1).toString();
@@ -113,14 +116,14 @@ import { requestLocationPermission } from "./permission.mjs";
           label: nextLabel
         });
         addBtn.disabled = false;
-        addBtn.textContent = 'Add Location';
+        addBtn.textContent = t('add_location');
       },
       err => {
-        showNotification(`Error getting current location: ${err.message}`, 'error');
+        showNotification(t('error_getting_current', { error: err.message }), 'error');
         const nextLabel = (appState.locations.length + 1).toString();
         showAddForm({ label: nextLabel });
         addBtn.disabled = false;
-        addBtn.textContent = 'Add Location';
+        addBtn.textContent = t('add_location');
       },
       { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
     );
@@ -174,7 +177,7 @@ import { requestLocationPermission } from "./permission.mjs";
     const lat = parseFloat(latInput.value);
     const lng = parseFloat(lngInput.value);
     if (!label || isNaN(lat) || isNaN(lng)) {
-      showNotification('Invalid input', 'error');
+      showNotification(t('invalid_input'), 'error');
       return;
     }
     const newLocation = {
@@ -193,10 +196,10 @@ import { requestLocationPermission } from "./permission.mjs";
   function clearAllLocations() {
     closeDrawer();
     if (appState.locations.length === 0) {
-      showNotification('There are no locations to clear.', 'info');
+      showNotification(t('no_locations_to_clear'), 'info');
       return;
     }
-    if (confirm('Are you sure you want to delete ALL locations? This cannot be undone.')) {
+    if (confirm(t('confirm_delete_all'))) {
       appState.locations = [];
       storage.saveLocations();
       mapModule.renderLocationsList();
@@ -206,7 +209,7 @@ import { requestLocationPermission } from "./permission.mjs";
   function exportToXml() {
     closeDrawer();
     if (appState.locations.length === 0) {
-      showNotification('No locations to export.', 'info');
+      showNotification(t('no_locations_to_export'), 'info');
       return;
     }
     const xmlDoc = document.implementation.createDocument(null, 'root', null);
@@ -251,12 +254,12 @@ import { requestLocationPermission } from "./permission.mjs";
         const xmlDoc = parser.parseFromString(xmlString, 'application/xml');
         const errorNode = xmlDoc.querySelector('parsererror');
         if (errorNode) {
-          showNotification('Error parsing XML file. Please check the file format.', 'error');
+          showNotification(t('error_parsing_xml'), 'error');
           return;
         }
         const plaatsElements = xmlDoc.getElementsByTagName('plaatsen');
         if (plaatsElements.length === 0) {
-          showNotification('No locations found in the XML file.', 'info');
+          showNotification(t('no_locations_in_file'), 'info');
           return;
         }
         appState.locations = [];
@@ -280,16 +283,16 @@ import { requestLocationPermission } from "./permission.mjs";
         if (importedCount > 0) {
           storage.saveLocations();
           mapModule.renderLocationsList();
-          showNotification(`${importedCount} location(s) imported successfully.`, 'success');
+          showNotification(t('locations_imported', { count: importedCount }), 'success');
         }
       } catch (error) {
-        showNotification('An error occurred while processing the XML file.', 'error');
+        showNotification(t('an_error_occurred'), 'error');
       }
       event.target.value = null;
       closeDrawer();
     };
     reader.onerror = function() {
-      showNotification('Error reading file.', 'error');
+      showNotification(t('error_reading_file'), 'error');
       event.target.value = null;
     };
     reader.readAsText(file);

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const { JSDOM } = require('jsdom');
+const { pathToFileURL } = require('url');
+
+let i18n;
+
+beforeAll(async () => {
+  const modPath = pathToFileURL(path.join(__dirname, '..', 'docs', 'i18n.mjs')).href;
+  i18n = await import(modPath);
+});
+
+test('all languages contain same translation keys', () => {
+  const keys = Object.keys(i18n.translations.en);
+  for (const lang of ['nl', 'de']) {
+    const langKeys = Object.keys(i18n.translations[lang]);
+    keys.forEach(k => expect(langKeys).toContain(k));
+  }
+});
+
+test('getUserLanguage picks supported language', () => {
+  const originalNav = global.navigator;
+  Object.defineProperty(global, 'navigator', { value: { languages: ['nl-NL', 'en-US'] }, configurable: true, writable: true });
+  expect(i18n.getUserLanguage()).toBe('nl');
+  Object.defineProperty(global, 'navigator', { value: { languages: ['de-DE'] }, configurable: true, writable: true });
+  expect(i18n.getUserLanguage()).toBe('de');
+  Object.defineProperty(global, 'navigator', { value: { languages: ['fr-FR'] }, configurable: true, writable: true });
+  expect(i18n.getUserLanguage()).toBe('en');
+  if (originalNav === undefined) delete global.navigator; else global.navigator = originalNav;
+});
+
+test('t returns translated text with variables', () => {
+  const originalNav = global.navigator;
+  Object.defineProperty(global, 'navigator', { value: { languages: ['de-DE'] }, configurable: true, writable: true });
+  i18n.applyTranslations();
+  expect(i18n.t('add_location')).toBe(i18n.translations.de.add_location);
+  expect(i18n.t('error_getting_current', { error: 'foo' })).toBe(
+    i18n.translations.de.error_getting_current.replace('{error}', 'foo')
+  );
+  if (originalNav === undefined) delete global.navigator; else global.navigator = originalNav;
+});


### PR DESCRIPTION
## Summary
- add i18n helper with English, Dutch and German texts
- translate index.html markup via data-i18n attributes
- apply translations on load in `main.mjs`
- localize dynamic messages in controllers and permission prompts
- add unit tests verifying language detection and translations

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852bd091e20832fa14d83b691a1281c