### PR TITLE
Fix GitHub CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   test:
@@ -14,5 +12,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: npm ci
+          cache: 'npm'
+      - run: npm install
       - run: npm test


### PR DESCRIPTION
## Summary
- run CI for all branches and pull requests
- cache npm modules for faster runs
- use `npm install` so workflow works without a lock file

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c23cb448832fb695c2556e2b15c0