### PR TITLE
Add refresh and move saved locations

### DIFF
--- a/docs/i18n.mjs
+++ b/docs/i18n.mjs
@@ -37,7 +37,9 @@ export const translations = {
     an_error_occurred: 'An error occurred while processing the XML file.',
     error_reading_file: 'Error reading file.',
     location_permission_denied: 'Location permission denied.',
-    location_permission_denied_enable: 'Location permission denied. Enable it in your browser settings.'
+    location_permission_denied_enable: 'Location permission denied. Enable it in your browser settings.',
+    force_refresh: 'Force Refresh',
+    no_internet: 'No internet connection. Unable to refresh.'
   },
   nl: {
     title: 'SaveLoc - Locaties opslaan',
@@ -77,7 +79,9 @@ export const translations = {
     an_error_occurred: 'Er is een fout opgetreden bij het verwerken van het XML-bestand.',
     error_reading_file: 'Fout bij het lezen van het bestand.',
     location_permission_denied: 'Locatietoestemming geweigerd.',
-    location_permission_denied_enable: 'Locatietoestemming geweigerd. Schakel dit in je browser in.'
+    location_permission_denied_enable: 'Locatietoestemming geweigerd. Schakel dit in je browser in.',
+    force_refresh: 'Ververs alles',
+    no_internet: 'Geen internetverbinding. Kan niet verversen.'
   },
   de: {
     title: 'SaveLoc - Orte speichern',
@@ -117,7 +121,9 @@ export const translations = {
     an_error_occurred: 'Beim Verarbeiten der XML-Datei ist ein Fehler aufgetreten.',
     error_reading_file: 'Fehler beim Lesen der Datei.',
     location_permission_denied: 'Standortberechtigung verweigert.',
-    location_permission_denied_enable: 'Standortberechtigung verweigert. Aktiviere sie in deinen Browsereinstellungen.'
+    location_permission_denied_enable: 'Standortberechtigung verweigert. Aktiviere sie in deinen Browsereinstellungen.',
+    force_refresh: 'Alles neu laden',
+    no_internet: 'Keine Internetverbindung. Aktualisierung nicht möglich.'
   }
 };
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,12 +30,8 @@
             <button id="exportXmlBtn" data-i18n="export_xml">Export as XML</button>
             <button id="importXmlBtnTrigger" data-i18n="import_xml">Import XML</button>
             <input type="file" id="importXmlInput" accept=".xml" style="display: none;">
-            
-            <section id="locations-list-section-drawer">
-                <h4 data-i18n="saved_locations">Saved Locations</h4>
-                <ul id="locationsList"></ul>
-                <div id="no-locations-message" class="hidden" data-i18n="no_locations">No locations saved yet.</div>
-            </section>
+            <button id="viewSavedLocationsBtn" data-i18n="saved_locations">Saved Locations</button>
+            <button id="forceRefreshBtn" data-i18n="force_refresh">Force Refresh</button>
         </div>
 
         <!-- Edit Form Section within Drawer (hidden by default) -->
@@ -87,6 +83,18 @@
             <div class="form-buttons-container">
                 <button type="button" id="saveLocationBtn" class="btn btn-primary" data-i18n="save_location">Save Location</button>
                 <button type="button" id="cancelFormBtn" class="btn btn-secondary" data-i18n="cancel">Cancel</button>
+            </div>
+        </div>
+    </section>
+
+    <!-- Saved Locations Modal -->
+    <section id="saved-locations-section" class="hidden">
+        <div class="form-content">
+            <h2 data-i18n="saved_locations">Saved Locations</h2>
+            <ul id="locationsList"></ul>
+            <div id="no-locations-message" class="hidden" data-i18n="no_locations"></div>
+            <div class="form-buttons-container">
+                <button type="button" id="closeSavedLocationsBtn" class="btn btn-secondary" data-i18n="cancel">Cancel</button>
             </div>
         </div>
     </section>

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -74,30 +74,36 @@ export function createLabelIcon(labelText, locId) {
 export function renderLocationsList() {
   const list = document.getElementById('locationsList');
   const message = document.getElementById('no-locations-message');
-  if (!list || !message) return;
+  const hasDom = list && message;
   let prevCenter = null;
   let prevZoom = null;
   if (appState.map) {
     prevCenter = appState.map.getCenter();
     prevZoom = appState.map.getZoom();
   }
-  list.innerHTML = '';
+  if (hasDom) list.innerHTML = '';
   if (appState.markersLayer) appState.markersLayer.clearLayers();
   appState.markers = {};
   if (appState.locations.length === 0) {
-    message.classList.remove('hidden');
-    list.classList.add('hidden');
+    if (hasDom) {
+      message.classList.remove('hidden');
+      list.classList.add('hidden');
+    }
     if (appState.map) appState.map.setView([20, 0], 2);
     return;
   }
-  message.classList.add('hidden');
-  list.classList.remove('hidden');
+  if (hasDom) {
+    message.classList.add('hidden');
+    list.classList.remove('hidden');
+  }
   const bounds = [];
   appState.locations.forEach(loc => {
-    const li = document.createElement('li');
-    li.setAttribute('data-id', loc.id);
-    li.textContent = loc.label || 'Unnamed';
-    list.appendChild(li);
+    if (hasDom) {
+      const li = document.createElement('li');
+      li.setAttribute('data-id', loc.id);
+      li.textContent = loc.label || 'Unnamed';
+      list.appendChild(li);
+    }
     if (appState.map && appState.markersLayer) {
       const marker = L.marker([loc.lat, loc.lng], {
         icon: createLabelIcon(loc.label, loc.id),

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -60,6 +60,22 @@ import { t } from "../i18n.mjs";
     showEditForm.currentId = null;
   }
 
+  function showSavedLocations() {
+    const section = document.getElementById('saved-locations-section');
+    if (!section) return;
+    showSavedLocations.lastFocus = document.activeElement;
+    mapModule.renderLocationsList();
+    section.classList.remove('hidden');
+    const closeBtn = document.getElementById('closeSavedLocationsBtn');
+    if (closeBtn) closeBtn.focus();
+  }
+
+  function hideSavedLocations() {
+    const section = document.getElementById('saved-locations-section');
+    if (section) section.classList.add('hidden');
+    if (showSavedLocations.lastFocus) showSavedLocations.lastFocus.focus();
+  }
+
   function toggleDrawer() {
     const drawer = document.getElementById('bottom-drawer');
     const closeBtn = document.getElementById('closeDrawerBtn');
@@ -243,6 +259,27 @@ import { t } from "../i18n.mjs";
     URL.revokeObjectURL(url);
   }
 
+  function forceRefresh() {
+    if (!navigator.onLine) {
+      showNotification(t('no_internet'), 'error');
+      return;
+    }
+    if (window.caches && caches.keys) {
+      caches.keys().then(keys => Promise.all(keys.map(k => caches.delete(k)))).then(() => {
+        if (navigator.serviceWorker && navigator.serviceWorker.getRegistrations) {
+          navigator.serviceWorker.getRegistrations().then(regs => {
+            regs.forEach(reg => reg.unregister());
+            window.location.reload(true);
+          });
+        } else {
+          window.location.reload(true);
+        }
+      });
+    } else {
+      window.location.reload(true);
+    }
+  }
+
   function handleFileImport(event) {
     const file = event.target.files[0];
     if (!file) return;
@@ -312,9 +349,12 @@ import { t } from "../i18n.mjs";
     const updateLocationToCurrentBtn = document.getElementById('updateLocationToCurrentBtn');
     const editLocationLatDrawer = document.getElementById('editLocationLatDrawer');
     const editLocationLngDrawer = document.getElementById('editLocationLngDrawer');
-    const importXmlBtnTrigger = document.getElementById('importXmlBtnTrigger');
-    const importXmlInput = document.getElementById('importXmlInput');
-    const locationsListUL = document.getElementById('locationsList');
+   const importXmlBtnTrigger = document.getElementById('importXmlBtnTrigger');
+   const importXmlInput = document.getElementById('importXmlInput');
+   const locationsListUL = document.getElementById('locationsList');
+    const viewSavedLocationsBtn = document.getElementById('viewSavedLocationsBtn');
+    const forceRefreshBtn = document.getElementById('forceRefreshBtn');
+    const closeSavedLocationsBtn = document.getElementById('closeSavedLocationsBtn');
 
     if (saveLocationBtn) saveLocationBtn.addEventListener('click', addOrUpdateLocation);
     if (cancelFormBtn) cancelFormBtn.addEventListener('click', hideAddForm);
@@ -336,6 +376,17 @@ import { t } from "../i18n.mjs";
       });
       importXmlInput.addEventListener('change', handleFileImport);
     }
+
+    if (viewSavedLocationsBtn) viewSavedLocationsBtn.addEventListener('click', () => {
+      closeDrawer();
+      showSavedLocations();
+    });
+    if (closeSavedLocationsBtn) closeSavedLocationsBtn.addEventListener('click', hideSavedLocations);
+
+    if (forceRefreshBtn) forceRefreshBtn.addEventListener('click', () => {
+      closeDrawer();
+      forceRefresh();
+    });
 
     document.addEventListener('keydown', e => {
       if (e.key === 'Escape') closeDrawer();
@@ -378,9 +429,12 @@ import { t } from "../i18n.mjs";
     hideAddForm,
     showEditForm,
     hideEditForm,
+    showSavedLocations,
+    hideSavedLocations,
     toggleDrawer,
     closeDrawer,
-    updateMarkerPosition: mapModule.updateMarkerPosition
+    updateMarkerPosition: mapModule.updateMarkerPosition,
+    forceRefresh
   };
 
 export default { init, testApi };

--- a/docs/style.css
+++ b/docs/style.css
@@ -184,7 +184,8 @@ html, body {
 }
 
 /* Location Form Modal Styles (remains mostly the same, but ensure z-index) */
-#location-form-section {
+#location-form-section,
+#saved-locations-section {
     position: fixed;
     top: 0;
     left: 0;
@@ -199,11 +200,13 @@ html, body {
     box-sizing: border-box;
 }
 
-#location-form-section.hidden {
+#location-form-section.hidden,
+#saved-locations-section.hidden {
     display: none !important; /* Keep using hidden class to toggle */
 }
 
-#location-form-section .form-content {
+#location-form-section .form-content,
+#saved-locations-section .form-content {
     background-color: #fff;
     padding: 25px;
     border-radius: 8px;
@@ -212,7 +215,8 @@ html, body {
     max-width: 400px;
 }
 
-#location-form-section h2 {
+#location-form-section h2,
+#saved-locations-section h2 {
     margin-top: 0;
     margin-bottom: 20px;
     color: #007bff;
@@ -220,14 +224,16 @@ html, body {
     text-align: center;
 }
 
-#location-form-section label {
+#location-form-section label,
+#saved-locations-section label {
     display: block;
     margin-bottom: 5px;
     font-weight: bold;
     font-size: 0.9rem;
 }
 
-#location-form-section input[type="text"] {
+#location-form-section input[type="text"],
+#saved-locations-section input[type="text"] {
     width: 100%; /* Full width within form */
     padding: 10px;
     margin-bottom: 15px;
@@ -415,10 +421,12 @@ html, body {
     .drawer-header h3 {
         font-size: 1.1rem;
     }
-    #location-form-section .form-content {
+    #location-form-section .form-content,
+    #saved-locations-section .form-content {
         padding: 20px;
     }
-    #location-form-section h2 {
+    #location-form-section h2,
+    #saved-locations-section h2 {
         font-size: 1.3rem;
     }
 }


### PR DESCRIPTION
## Summary
- add refresh button to menu
- move saved locations to new page
- allow map rendering without list DOM
- localize refresh strings
- cache new page in service worker
- show saved locations in a modal instead of a separate page

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c73f9c0c832f8e735df7a89e0f96