### PR TITLE
Add menu-based layer selector

### DIFF
--- a/docs/i18n.mjs
+++ b/docs/i18n.mjs
@@ -39,6 +39,7 @@ export const translations = {
     location_permission_denied: 'Location permission denied.',
     location_permission_denied_enable: 'Location permission denied. Enable it in your browser settings.',
     force_refresh: 'Force Refresh',
+    map_layer: 'Map Layer',
     no_internet: 'No internet connection. Unable to refresh.'
   },
   nl: {
@@ -81,6 +82,7 @@ export const translations = {
     location_permission_denied: 'Locatietoestemming geweigerd.',
     location_permission_denied_enable: 'Locatietoestemming geweigerd. Schakel dit in je browser in.',
     force_refresh: 'Ververs alles',
+    map_layer: 'Kaartlaag',
     no_internet: 'Geen internetverbinding. Kan niet verversen.'
   },
   de: {
@@ -123,6 +125,7 @@ export const translations = {
     location_permission_denied: 'Standortberechtigung verweigert.',
     location_permission_denied_enable: 'Standortberechtigung verweigert. Aktiviere sie in deinen Browsereinstellungen.',
     force_refresh: 'Alles neu laden',
+    map_layer: 'Kartenansicht',
     no_internet: 'Keine Internetverbindung. Aktualisierung nicht möglich.'
   }
 };

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,6 +32,8 @@
             <input type="file" id="importXmlInput" accept=".xml" style="display: none;">
             <button id="viewSavedLocationsBtn" data-i18n="saved_locations">Saved Locations</button>
             <button id="forceRefreshBtn" data-i18n="force_refresh">Force Refresh</button>
+            <label for="mapLayerSelect" class="inline-select-label" data-i18n="map_layer">Map Layer</label>
+            <select id="mapLayerSelect" class="inline-select"></select>
         </div>
 
         <!-- Edit Form Section within Drawer (hidden by default) -->

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -185,6 +185,20 @@ import { t } from "../i18n.mjs";
     }
   }
 
+  function populateLayerSelect() {
+    const select = document.getElementById('mapLayerSelect');
+    if (!select) return;
+    const names = mapModule.getBaseLayerNames();
+    select.innerHTML = '';
+    names.forEach(n => {
+      const opt = document.createElement('option');
+      opt.value = n;
+      opt.textContent = n;
+      select.appendChild(opt);
+    });
+    select.value = mapModule.getCurrentBaseLayerName();
+  }
+
   function addOrUpdateLocation() {
     const labelInput = document.getElementById('locationLabel');
     const latInput = document.getElementById('locationLat');
@@ -353,8 +367,9 @@ import { t } from "../i18n.mjs";
    const importXmlInput = document.getElementById('importXmlInput');
    const locationsListUL = document.getElementById('locationsList');
     const viewSavedLocationsBtn = document.getElementById('viewSavedLocationsBtn');
-    const forceRefreshBtn = document.getElementById('forceRefreshBtn');
-    const closeSavedLocationsBtn = document.getElementById('closeSavedLocationsBtn');
+   const forceRefreshBtn = document.getElementById('forceRefreshBtn');
+   const closeSavedLocationsBtn = document.getElementById('closeSavedLocationsBtn');
+   const mapLayerSelect = document.getElementById('mapLayerSelect');
 
     if (saveLocationBtn) saveLocationBtn.addEventListener('click', addOrUpdateLocation);
     if (cancelFormBtn) cancelFormBtn.addEventListener('click', hideAddForm);
@@ -383,9 +398,13 @@ import { t } from "../i18n.mjs";
     });
     if (closeSavedLocationsBtn) closeSavedLocationsBtn.addEventListener('click', hideSavedLocations);
 
-    if (forceRefreshBtn) forceRefreshBtn.addEventListener('click', () => {
-      closeDrawer();
-      forceRefresh();
+   if (forceRefreshBtn) forceRefreshBtn.addEventListener('click', () => {
+     closeDrawer();
+     forceRefresh();
+   });
+
+    if (mapLayerSelect) mapLayerSelect.addEventListener('change', e => {
+      mapModule.setBaseLayer(e.target.value);
     });
 
     document.addEventListener('keydown', e => {
@@ -408,6 +427,7 @@ import { t } from "../i18n.mjs";
     mapModule.setMarkerClickHandler(showEditForm);
     mapModule.loadMap().then(() => {
       mapModule.renderLocationsList();
+      populateLayerSelect();
       requestLocationPermission();
     });
   }

--- a/docs/style.css
+++ b/docs/style.css
@@ -319,6 +319,21 @@ html, body {
     background-color: #5a6268; /* Darker grey */
 }
 
+/* Inline select for map layer choice */
+.inline-select-label {
+    display: block;
+    margin: 10px 5px 5px;
+    font-weight: bold;
+}
+
+.inline-select {
+    display: block;
+    width: calc(100% - 10px);
+    margin: 0 5px 10px;
+    padding: 10px;
+    font-size: 1rem;
+}
+
 /* Optional: if update button needs specific style different from primary */
 .btn-update {
     background-color: #007bff; /* Blue */


### PR DESCRIPTION
## Summary
- remove Leaflet layer control from the map
- expose base layer utilities in `map.mjs`
- add layer dropdown in the drawer menu
- populate dropdown on load and handle changes
- style inline select element
- provide i18n strings for map layer label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852d07c5508832f9e6772f78d6285f4