### PR TITLE
Implement new menu behaviors

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,17 +23,16 @@
     <div id="bottom-drawer">
         <div class="drawer-header">
             <h3 data-i18n="menu">Menu</h3>
+            <button id="forceRefreshBtn" aria-label="Force Refresh" data-i18n-aria-label="force_refresh">⟳</button>
             <button id="closeDrawerBtn" aria-label="Close menu" data-i18n-aria-label="close_menu">×</button>
         </div>
         <div class="drawer-content" id="drawer-main-content">
+            <select id="mapLayerSelect" class="inline-select" aria-label="Map Layer" data-i18n-aria-label="map_layer"></select>
             <button id="clearListBtn" data-i18n="clear_all">Clear All Locations</button>
             <button id="exportXmlBtn" data-i18n="export_xml">Export as XML</button>
             <button id="importXmlBtnTrigger" data-i18n="import_xml">Import XML</button>
             <input type="file" id="importXmlInput" accept=".xml" style="display: none;">
             <button id="viewSavedLocationsBtn" data-i18n="saved_locations">Saved Locations</button>
-            <button id="forceRefreshBtn" data-i18n="force_refresh">Force Refresh</button>
-            <label for="mapLayerSelect" class="inline-select-label" data-i18n="map_layer">Map Layer</label>
-            <select id="mapLayerSelect" class="inline-select"></select>
         </div>
 
         <!-- Edit Form Section within Drawer (hidden by default) -->

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -411,6 +411,14 @@ import { t } from "../i18n.mjs";
       if (e.key === 'Escape') closeDrawer();
     });
 
+    document.addEventListener('click', e => {
+      const drawer = document.getElementById('bottom-drawer');
+      if (!drawer || !drawer.classList.contains('visible')) return;
+      if (!drawer.contains(e.target) && e.target !== hamburgerBtn) {
+        closeDrawer();
+      }
+    });
+
     if (locationsListUL) {
       locationsListUL.addEventListener('click', e => {
         const li = e.target.closest('li[data-id]');

--- a/docs/style.css
+++ b/docs/style.css
@@ -109,6 +109,15 @@ html, body {
     padding: 5px;
 }
 
+#forceRefreshBtn {
+    background: none;
+    border: none;
+    font-size: 1.4rem;
+    color: #555;
+    cursor: pointer;
+    padding: 5px;
+}
+
 .drawer-content {
     padding: 15px;
     overflow-y: auto; /* Allow scrolling for content */

--- a/tests/drawer.test.js
+++ b/tests/drawer.test.js
@@ -31,3 +31,15 @@ test('drawer closes with button and Escape key', () => {
   document.dispatchEvent(esc);
   expect(drawer.classList.contains('visible')).toBe(false);
 });
+
+test('clicking outside drawer closes it', () => {
+  const hamburger = document.getElementById('hamburgerBtn');
+  const drawer = document.getElementById('bottom-drawer');
+
+  hamburger.click();
+  expect(drawer.classList.contains('visible')).toBe(true);
+
+  document.body.click();
+
+  expect(drawer.classList.contains('visible')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- close drawer when clicking outside
- make force refresh an icon in drawer header
- move map layer select to top of menu
- add CSS for new icon button
- test closing drawer with outside click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852d401e784832f937915ee769b6e4e