### PR TITLE
Rearrange drawer header

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,8 +22,8 @@
 
     <div id="bottom-drawer">
         <div class="drawer-header">
-            <h3 data-i18n="menu">Menu</h3>
             <button id="forceRefreshBtn" aria-label="Force Refresh" data-i18n-aria-label="force_refresh">⟳</button>
+            <h3 class="app-title">Marketlocs</h3>
             <button id="closeDrawerBtn" aria-label="Close menu" data-i18n-aria-label="close_menu">×</button>
         </div>
         <div class="drawer-content" id="drawer-main-content">

--- a/docs/style.css
+++ b/docs/style.css
@@ -100,6 +100,11 @@ html, body {
     color: #333;
 }
 
+.drawer-header .app-title {
+    flex-grow: 1;
+    text-align: center;
+}
+
 #closeDrawerBtn {
     background: none;
     border: none;


### PR DESCRIPTION
## Summary
- tweak drawer header layout so refresh button sits on the left
- center the title and show the app name

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852d69ef9f0832fa3678b641deb6650