### PR TITLE
Remove saved locations list and rely on long‑press editing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -32,7 +32,6 @@
             <button id="exportXmlBtn" data-i18n="export_xml">Export as XML</button>
             <button id="importXmlBtnTrigger" data-i18n="import_xml">Import XML</button>
             <input type="file" id="importXmlInput" accept=".xml" style="display: none;">
-            <button id="viewSavedLocationsBtn" data-i18n="saved_locations">Saved Locations</button>
         </div>
 
         <!-- Edit Form Section within Drawer (hidden by default) -->
@@ -88,17 +87,6 @@
         </div>
     </section>
 
-    <!-- Saved Locations Modal -->
-    <section id="saved-locations-section" class="hidden">
-        <div class="form-content">
-            <h2 data-i18n="saved_locations">Saved Locations</h2>
-            <ul id="locationsList"></ul>
-            <div id="no-locations-message" class="hidden" data-i18n="no_locations"></div>
-            <div class="form-buttons-container">
-                <button type="button" id="closeSavedLocationsBtn" class="btn btn-secondary" data-i18n="cancel">Cancel</button>
-            </div>
-        </div>
-    </section>
 
     <!-- Footer can be minimal or removed if drawer takes up space -->
     <!-- 

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -108,7 +108,7 @@ export function renderLocationsList() {
         draggable: appState.isInEditMode
       }).addTo(appState.markersLayer);
       marker.locationId = loc.id;
-      if (markerClickHandler) marker.on('click', () => markerClickHandler(loc));
+      if (markerClickHandler) marker.on('contextmenu', () => markerClickHandler(loc));
       marker.on('dragend', evt => {
         const m = evt.target.getLatLng();
         const idx = appState.locations.findIndex(l => l.id === loc.id);

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -60,21 +60,6 @@ import { t } from "../i18n.mjs";
     showEditForm.currentId = null;
   }
 
-  function showSavedLocations() {
-    const section = document.getElementById('saved-locations-section');
-    if (!section) return;
-    showSavedLocations.lastFocus = document.activeElement;
-    mapModule.renderLocationsList();
-    section.classList.remove('hidden');
-    const closeBtn = document.getElementById('closeSavedLocationsBtn');
-    if (closeBtn) closeBtn.focus();
-  }
-
-  function hideSavedLocations() {
-    const section = document.getElementById('saved-locations-section');
-    if (section) section.classList.add('hidden');
-    if (showSavedLocations.lastFocus) showSavedLocations.lastFocus.focus();
-  }
 
   function toggleDrawer() {
     const drawer = document.getElementById('bottom-drawer');
@@ -365,10 +350,7 @@ import { t } from "../i18n.mjs";
     const editLocationLngDrawer = document.getElementById('editLocationLngDrawer');
    const importXmlBtnTrigger = document.getElementById('importXmlBtnTrigger');
    const importXmlInput = document.getElementById('importXmlInput');
-   const locationsListUL = document.getElementById('locationsList');
-    const viewSavedLocationsBtn = document.getElementById('viewSavedLocationsBtn');
    const forceRefreshBtn = document.getElementById('forceRefreshBtn');
-   const closeSavedLocationsBtn = document.getElementById('closeSavedLocationsBtn');
    const mapLayerSelect = document.getElementById('mapLayerSelect');
 
     if (saveLocationBtn) saveLocationBtn.addEventListener('click', addOrUpdateLocation);
@@ -392,11 +374,7 @@ import { t } from "../i18n.mjs";
       importXmlInput.addEventListener('change', handleFileImport);
     }
 
-    if (viewSavedLocationsBtn) viewSavedLocationsBtn.addEventListener('click', () => {
-      closeDrawer();
-      showSavedLocations();
-    });
-    if (closeSavedLocationsBtn) closeSavedLocationsBtn.addEventListener('click', hideSavedLocations);
+
 
    if (forceRefreshBtn) forceRefreshBtn.addEventListener('click', () => {
      closeDrawer();
@@ -419,14 +397,6 @@ import { t } from "../i18n.mjs";
       }
     });
 
-    if (locationsListUL) {
-      locationsListUL.addEventListener('click', e => {
-        const li = e.target.closest('li[data-id]');
-        if (!li) return;
-        const loc = appState.locations.find(l => l.id === li.dataset.id);
-        if (loc) showEditForm(loc);
-      });
-    }
   }
 
   function init() {
@@ -457,8 +427,6 @@ import { t } from "../i18n.mjs";
     hideAddForm,
     showEditForm,
     hideEditForm,
-    showSavedLocations,
-    hideSavedLocations,
     toggleDrawer,
     closeDrawer,
     updateMarkerPosition: mapModule.updateMarkerPosition,

--- a/docs/style.css
+++ b/docs/style.css
@@ -159,47 +159,9 @@ html, body {
     font-size: 1.1rem;
 }
 
-#locationsList {
-    list-style: none;
-    padding: 0;
-}
-
-#locationsList li {
-    padding: 10px;
-    border-bottom: 1px solid #eee;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    font-size: 0.95rem;
-}
-
-#locationsList li:last-child {
-    border-bottom: none;
-}
-
-#locationsList .location-label {
-    font-weight: bold;
-}
-
-#locationsList .location-coords {
-    font-size: 0.85em;
-    color: #555;
-    margin-left: 8px;
-}
-
-#locationsList .actions button {
-    padding: 5px 10px;
-    font-size: 0.85em;
-    margin-left: 5px;
-    background-color: #6c757d;
-}
-#locationsList .actions button:hover {
-    background-color: #5a6268;
-}
 
 /* Location Form Modal Styles (remains mostly the same, but ensure z-index) */
-#location-form-section,
-#saved-locations-section {
+#location-form-section {
     position: fixed;
     top: 0;
     left: 0;
@@ -214,13 +176,11 @@ html, body {
     box-sizing: border-box;
 }
 
-#location-form-section.hidden,
-#saved-locations-section.hidden {
+#location-form-section.hidden {
     display: none !important; /* Keep using hidden class to toggle */
 }
 
-#location-form-section .form-content,
-#saved-locations-section .form-content {
+#location-form-section .form-content {
     background-color: #fff;
     padding: 25px;
     border-radius: 8px;
@@ -229,8 +189,7 @@ html, body {
     max-width: 400px;
 }
 
-#location-form-section h2,
-#saved-locations-section h2 {
+#location-form-section h2 {
     margin-top: 0;
     margin-bottom: 20px;
     color: #007bff;
@@ -238,16 +197,14 @@ html, body {
     text-align: center;
 }
 
-#location-form-section label,
-#saved-locations-section label {
+#location-form-section label {
     display: block;
     margin-bottom: 5px;
     font-weight: bold;
     font-size: 0.9rem;
 }
 
-#location-form-section input[type="text"],
-#saved-locations-section input[type="text"] {
+#location-form-section input[type="text"] {
     width: 100%; /* Full width within form */
     padding: 10px;
     margin-bottom: 15px;
@@ -450,12 +407,10 @@ html, body {
     .drawer-header h3 {
         font-size: 1.1rem;
     }
-    #location-form-section .form-content,
-    #saved-locations-section .form-content {
+    #location-form-section .form-content {
         padding: 20px;
     }
-    #location-form-section h2,
-    #saved-locations-section h2 {
+    #location-form-section h2 {
         font-size: 1.3rem;
     }
 }

--- a/tests/additional.test.js
+++ b/tests/additional.test.js
@@ -16,17 +16,6 @@ beforeEach(() => {
   window.L.__markers.length = 0;
 });
 
-test('showSavedLocations displays section and restores focus on hide', () => {
-  const trigger = document.getElementById('viewSavedLocationsBtn');
-  trigger.focus();
-  const section = document.getElementById('saved-locations-section');
-  saveLocTest.showSavedLocations();
-  expect(section.classList.contains('hidden')).toBe(false);
-  expect(document.activeElement).toBe(document.getElementById('closeSavedLocationsBtn'));
-  saveLocTest.hideSavedLocations();
-  expect(section.classList.contains('hidden')).toBe(true);
-  expect(document.activeElement).toBe(trigger);
-});
 
 test('updateMarkerPosition updates marker coords', () => {
   const loc = { id: '1', lat: 1, lng: 2, label: 'A' };


### PR DESCRIPTION
## Summary
- drop saved locations modal and button
- edit markers via long‑press (`contextmenu` event)
- clean unused styles and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852d9647698832faa9b3970b8c6a834