### PR TITLE
Add wiggling animation for markers in edit mode

### DIFF
--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -62,7 +62,7 @@ export function createLabelIcon(labelText, locId) {
   const displayLabel = labelText && labelText.trim() !== '' ? labelText.substring(0, 15) : '📍';
   return L.divIcon({
     html: `<div class="custom-label-marker-text">${displayLabel.replace(/[<>&'"\\/]/g, c => '&#' + c.charCodeAt(0) + ';')}</div>`,
-    className: 'custom-label-marker location-marker-' + locId,
+    className: 'custom-label-marker location-marker-' + locId + (appState.isInEditMode ? ' wiggle-marker' : ''),
     iconSize: null,
     iconAnchor: [20, 10],
     popupAnchor: [0, -10]

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -60,9 +60,10 @@ export function initMap() {
 
 export function createLabelIcon(labelText, locId) {
   const displayLabel = labelText && labelText.trim() !== '' ? labelText.substring(0, 15) : '📍';
+  const wiggleClass = appState.isInEditMode ? ' wiggle-marker' : '';
   return L.divIcon({
-    html: `<div class="custom-label-marker-text">${displayLabel.replace(/[<>&'"\\/]/g, c => '&#' + c.charCodeAt(0) + ';')}</div>`,
-    className: 'custom-label-marker location-marker-' + locId + (appState.isInEditMode ? ' wiggle-marker' : ''),
+    html: `<div class="custom-label-marker-text${wiggleClass}">${displayLabel.replace(/[<>&'"\\/]/g, c => '&#' + c.charCodeAt(0) + ';')}</div>`,
+    className: 'custom-label-marker location-marker-' + locId,
     iconSize: null,
     iconAnchor: [20, 10],
     popupAnchor: [0, -10]

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -34,6 +34,22 @@ const baseLayers = {
 let currentBaseLayer = null;
 let currentBaseLayerName = null;
 
+// Placeholder orientation logic. In a full implementation this would fetch the
+// nearest road and calculate its bearing so markers can rotate parallel to it.
+export async function getRoadOrientation(lat, lng) {
+  // Network access to road data is blocked in the current environment.
+  // Returning 0 degrees until road orientation can be determined.
+  return 0;
+}
+
+export async function applyRoadOrientation(marker) {
+  const { lat, lng } = marker.getLatLng();
+  const angle = await getRoadOrientation(lat, lng);
+  if (marker._icon) {
+    marker._icon.style.transform = `rotate(${angle}deg)`;
+  }
+}
+
 export function loadMap() {
   return new Promise((resolve, reject) => {
     try {
@@ -108,6 +124,7 @@ export function renderLocationsList() {
         icon: createLabelIcon(loc.label, loc.id),
         draggable: appState.isInEditMode
       }).addTo(appState.markersLayer);
+      applyRoadOrientation(marker);
       marker.locationId = loc.id;
       if (markerClickHandler) marker.on('contextmenu', () => markerClickHandler(loc));
       marker.on('dragend', evt => {
@@ -118,6 +135,7 @@ export function renderLocationsList() {
           appState.locations[idx].lng = m.lng;
           saveLocations();
         }
+        applyRoadOrientation(evt.target);
       });
       appState.markers[loc.id] = marker;
       bounds.push([loc.lat, loc.lng]);

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -169,6 +169,9 @@ function setupRotationHandling(marker, loc) {
     if (!e.shiftKey) return;
     L.DomEvent.stop(e);
     if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+    if (appState.map && appState.map.boxZoom && appState.map.boxZoom._enabled) {
+      appState.map.boxZoom.disable();
+    }
     const center = getCenterPoint();
     const start = Math.atan2(e.clientY - center.y, e.clientX - center.x);
     const startOffset = loc.rotation || 0;
@@ -182,6 +185,9 @@ function setupRotationHandling(marker, loc) {
     function onUp() {
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
+      if (appState.map && appState.map.boxZoom && !appState.map.boxZoom._enabled) {
+        appState.map.boxZoom.enable();
+      }
       saveLocations();
     }
     document.addEventListener('mousemove', onMove);

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -166,7 +166,8 @@ function setupRotationHandling(marker, loc) {
   }
 
   function onMouseDown(e) {
-    if (!e.shiftKey) return;
+    // Use Alt/Option drag to rotate so Shift can remain for box zoom
+    if (!e.altKey) return;
     L.DomEvent.stop(e);
     if (e.stopImmediatePropagation) e.stopImmediatePropagation();
     if (appState.map && appState.map.boxZoom && appState.map.boxZoom._enabled) {

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -227,11 +227,19 @@ function setupRotationHandling(marker, loc) {
     document.addEventListener('touchcancel', onEnd);
   }
 
-  marker.on('add', () => {
+  function attachHandlers() {
     if (!marker._icon) return;
     marker._icon.addEventListener('mousedown', onMouseDown, { passive: false, capture: true });
     marker._icon.addEventListener('touchstart', onTouchStart, { passive: false, capture: true });
-  });
+  }
+
+  marker._attachRotationListeners = attachHandlers;
+
+  if (marker._icon) {
+    attachHandlers();
+  }
+
+  marker.on('add', attachHandlers);
 }
 
 export function renderLocationsList() {
@@ -322,6 +330,9 @@ export function updateAllMarkerSizes() {
     if (!marker) return;
     const icon = createLabelIcon(loc.label, loc.id, marker.getLatLng());
     marker.setIcon(icon);
+    if (typeof marker._attachRotationListeners === 'function') {
+      marker._attachRotationListeners();
+    }
     applyRoadOrientation(marker);
   });
 }

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -168,6 +168,7 @@ function setupRotationHandling(marker, loc) {
   function onMouseDown(e) {
     if (!e.shiftKey) return;
     L.DomEvent.stop(e);
+    if (e.stopImmediatePropagation) e.stopImmediatePropagation();
     const center = getCenterPoint();
     const start = Math.atan2(e.clientY - center.y, e.clientX - center.x);
     const startOffset = loc.rotation || 0;
@@ -191,6 +192,7 @@ function setupRotationHandling(marker, loc) {
     if (e.touches.length !== 2) return;
     e.preventDefault();
     L.DomEvent.stop(e);
+    if (e.stopImmediatePropagation) e.stopImmediatePropagation();
     const getAng = ev => {
       const t1 = ev.touches[0];
       const t2 = ev.touches[1];
@@ -220,8 +222,8 @@ function setupRotationHandling(marker, loc) {
 
   marker.on('add', () => {
     if (!marker._icon) return;
-    marker._icon.addEventListener('mousedown', onMouseDown);
-    marker._icon.addEventListener('touchstart', onTouchStart, { passive: false });
+    marker._icon.addEventListener('mousedown', onMouseDown, { passive: false, capture: true });
+    marker._icon.addEventListener('touchstart', onTouchStart, { passive: false, capture: true });
   });
 }
 

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -43,11 +43,12 @@ export async function getRoadOrientation(lat, lng) {
 }
 
 export async function applyRoadOrientation(marker) {
+  if (!marker._icon) return;
+  const inner = marker._icon.querySelector('.custom-label-marker-inner');
+  if (!inner) return;
   const { lat, lng } = marker.getLatLng();
   const angle = await getRoadOrientation(lat, lng);
-  if (marker._icon) {
-    marker._icon.style.transform = `rotate(${angle}deg)`;
-  }
+  inner.style.setProperty('--rotation', `${angle}deg`);
 }
 
 export function loadMap() {
@@ -75,10 +76,13 @@ export function initMap() {
 }
 
 export function createLabelIcon(labelText, locId) {
-  const displayLabel = labelText && labelText.trim() !== '' ? labelText.substring(0, 15) : '📍';
+  const displayLabel = labelText && labelText.trim() !== ''
+    ? labelText.substring(0, 15)
+    : '📍';
   const wiggleClass = appState.isInEditMode ? ' wiggle-marker' : '';
+  const safe = displayLabel.replace(/[<>&'"\\/]/g, c => '&#' + c.charCodeAt(0) + ';');
   return L.divIcon({
-    html: `<div class="custom-label-marker-text${wiggleClass}">${displayLabel.replace(/[<>&'"\\/]/g, c => '&#' + c.charCodeAt(0) + ';')}</div>`,
+    html: `<div class="custom-label-marker-inner${wiggleClass}"><div class="custom-label-marker-text">${safe}</div></div>`,
     className: 'custom-label-marker location-marker-' + locId,
     iconSize: null,
     iconAnchor: [20, 10],

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -67,7 +67,8 @@ export async function applyRoadOrientation(marker) {
   if (!inner) return;
   const { lat, lng } = marker.getLatLng();
   const angle = await getRoadOrientation(lat, lng);
-  inner.style.setProperty('--rotation', `${angle}deg`);
+  const rotation = angle - 90;
+  inner.style.setProperty('--rotation', `${rotation}deg`);
 }
 
 export function loadMap() {

--- a/docs/src/map.mjs
+++ b/docs/src/map.mjs
@@ -42,8 +42,8 @@ let orientationFetchDisabled = false;
 // Fetch the angle of the nearest road around the given point using the
 // Overpass API. 0 degrees is returned if no road data is available.
 export async function getRoadOrientation(lat, lng) {
-  // round coordinates to roughly 1 meter precision
-  const key = `${lat.toFixed(5)},${lng.toFixed(5)}`;
+  // round coordinates to roughly 10 meter precision to limit unique requests
+  const key = `${lat.toFixed(4)},${lng.toFixed(4)}`;
   if (orientationCache.has(key)) {
     return orientationCache.get(key);
   }

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -433,6 +433,8 @@ import { t } from "../i18n.mjs";
     setBaseLayer: mapModule.setBaseLayer,
     getBaseLayerNames: mapModule.getBaseLayerNames,
     getCurrentBaseLayerName: mapModule.getCurrentBaseLayerName,
+    applyRoadOrientation: mapModule.applyRoadOrientation,
+    getRoadOrientation: mapModule.getRoadOrientation,
     forceRefresh
   };
 

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -142,7 +142,8 @@ import { t } from "../i18n.mjs";
         ...appState.locations[index],
         label: labelField.value.trim(),
         lat: parseFloat(latField.value),
-        lng: parseFloat(lngField.value)
+        lng: parseFloat(lngField.value),
+        rotation: appState.locations[index].rotation || 0
       };
       storage.saveLocations();
       mapModule.renderLocationsList();
@@ -200,6 +201,7 @@ import { t } from "../i18n.mjs";
       label,
       lat,
       lng,
+      rotation: 0,
       timestamp: new Date().toISOString()
     };
     appState.locations.push(newLocation);

--- a/docs/src/ui-controller.mjs
+++ b/docs/src/ui-controller.mjs
@@ -435,6 +435,7 @@ import { t } from "../i18n.mjs";
     getCurrentBaseLayerName: mapModule.getCurrentBaseLayerName,
     applyRoadOrientation: mapModule.applyRoadOrientation,
     getRoadOrientation: mapModule.getRoadOrientation,
+    updateAllMarkerSizes: mapModule.updateAllMarkerSizes,
     forceRefresh
   };
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -370,7 +370,8 @@ html, body {
 }
 
 /* Custom Label Marker Styles (from previous implementation) */
-.custom-label-marker {
+
+.custom-label-marker-inner {
     background-color: white;
     border: 1px solid #007bff;
     border-radius: 0;
@@ -379,6 +380,8 @@ html, body {
     text-align: center;
     white-space: nowrap;
     transform-origin: center;
+    transform: rotate(var(--rotation, 0deg));
+    display: inline-block;
 }
 
 .custom-label-marker-text {
@@ -398,9 +401,9 @@ html, body {
 }
 
 @keyframes wiggle {
-    0%, 100% { transform: rotate(0deg); }
-    25% { transform: rotate(3deg); }
-    75% { transform: rotate(-3deg); }
+    0%, 100% { transform: rotate(calc(var(--rotation, 0deg) + 0deg)); }
+    25% { transform: rotate(calc(var(--rotation, 0deg) + 3deg)); }
+    75% { transform: rotate(calc(var(--rotation, 0deg) - 3deg)); }
 }
 
 .wiggle-marker {

--- a/docs/style.css
+++ b/docs/style.css
@@ -395,6 +395,16 @@ html, body {
     font-size: 14px;
 }
 
+@keyframes wiggle {
+    0%, 100% { transform: rotate(0deg); }
+    25% { transform: rotate(3deg); }
+    75% { transform: rotate(-3deg); }
+}
+
+.wiggle-marker {
+    animation: wiggle 0.6s ease-in-out infinite;
+}
+
 /* Minor adjustments for very small screens if needed */
 @media (max-width: 360px) {
     #top-bar button {

--- a/docs/style.css
+++ b/docs/style.css
@@ -373,11 +373,12 @@ html, body {
 .custom-label-marker {
     background-color: white;
     border: 1px solid #007bff;
-    border-radius: 20px;
+    border-radius: 0;
     padding: 3px 8px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
     text-align: center;
     white-space: nowrap;
+    transform-origin: center;
 }
 
 .custom-label-marker-text {

--- a/docs/style.css
+++ b/docs/style.css
@@ -388,6 +388,7 @@ html, body {
     max-width: 100px;
     overflow: hidden;
     text-overflow: ellipsis;
+    display: inline-block;
 }
 
 .custom-label-marker-text:empty::before {

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -87,6 +87,13 @@ test('applyRoadOrientation sets rotation transform', async () => {
   const iconEl = document.createElement('div');
   iconEl.appendChild(inner);
   const marker = { getLatLng: () => ({ lat: 0, lng: 0 }), _icon: iconEl };
+  const fake = jest.fn(() => Promise.resolve({
+    ok: true,
+    json: async () => ({ elements: [ { geometry: [ { lat: 0, lon: 0 }, { lat: 0, lon: 1 } ] } ] })
+  }));
+  global.fetch = fake;
+  window.fetch = fake;
   await saveLocTest.applyRoadOrientation(marker);
-  expect(inner.style.getPropertyValue('--rotation')).toContain('deg');
+  expect(fake).toHaveBeenCalled();
+  expect(inner.style.getPropertyValue('--rotation')).toContain('90');
 });

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -103,3 +103,14 @@ test('applyRoadOrientation sets rotation transform', async () => {
   expect(fake).toHaveBeenCalled();
   expect(inner.style.getPropertyValue('--rotation')).toContain('0');
 });
+
+test('getRoadOrientation caches failures', async () => {
+  const fake = jest.fn(() => Promise.reject(new Error('fail')));
+  global.fetch = fake;
+  window.fetch = fake;
+  const first = await saveLocTest.getRoadOrientation(1, 1);
+  expect(first).toBe(0);
+  const second = await saveLocTest.getRoadOrientation(1, 1);
+  expect(second).toBe(0);
+  expect(fake).toHaveBeenCalledTimes(1);
+});

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -92,7 +92,7 @@ test('applyRoadOrientation sets rotation transform', async () => {
   inner.className = 'custom-label-marker-inner';
   const iconEl = document.createElement('div');
   iconEl.appendChild(inner);
-  const marker = { getLatLng: () => ({ lat: 0, lng: 0 }), _icon: iconEl };
+  const marker = { getLatLng: () => ({ lat: 0, lng: 0 }), _icon: iconEl, rotation: 30 };
   const fake = jest.fn(() => Promise.resolve({
     ok: true,
     json: async () => ({ elements: [ { geometry: [ { lat: 0, lon: 0 }, { lat: 0, lon: 1 } ] } ] })
@@ -101,7 +101,7 @@ test('applyRoadOrientation sets rotation transform', async () => {
   window.fetch = fake;
   await saveLocTest.applyRoadOrientation(marker);
   expect(fake).toHaveBeenCalled();
-  expect(inner.style.getPropertyValue('--rotation')).toContain('0');
+  expect(inner.style.getPropertyValue('--rotation')).toContain('30');
 });
 
 test('getRoadOrientation caches failures', async () => {

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -95,5 +95,5 @@ test('applyRoadOrientation sets rotation transform', async () => {
   window.fetch = fake;
   await saveLocTest.applyRoadOrientation(marker);
   expect(fake).toHaveBeenCalled();
-  expect(inner.style.getPropertyValue('--rotation')).toContain('90');
+  expect(inner.style.getPropertyValue('--rotation')).toContain('0');
 });

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -76,6 +76,7 @@ test('createLabelIcon adds wiggle class in edit mode', () => {
   window.L.divIcon = jest.fn(opts => opts);
   window.appState.isInEditMode = true;
   const icon = saveLocTest.createLabelIcon('A', '2');
-  expect(icon.className).toContain('wiggle-marker');
+  expect(icon.html).toContain('wiggle-marker');
+  expect(icon.className).not.toContain('wiggle-marker');
   window.appState.isInEditMode = false;
 });

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -67,7 +67,7 @@ test('clearAllLocations empties stored locations when confirmed', () => {
 
 test('createLabelIcon sanitizes label text', () => {
   window.L.divIcon = jest.fn(opts => opts);
-  const icon = saveLocTest.createLabelIcon('Hi <b>', '1');
+  const icon = saveLocTest.createLabelIcon('Hi <b>', '1', { lat: 0, lng: 0 });
   expect(icon.html).toContain('Hi');
   expect(icon.html).not.toContain('<b>');
 });
@@ -75,10 +75,16 @@ test('createLabelIcon sanitizes label text', () => {
 test('createLabelIcon adds wiggle class in edit mode', () => {
   window.L.divIcon = jest.fn(opts => opts);
   window.appState.isInEditMode = true;
-  const icon = saveLocTest.createLabelIcon('A', '2');
+  const icon = saveLocTest.createLabelIcon('A', '2', { lat: 0, lng: 0 });
   expect(icon.html).toContain('wiggle-marker');
   expect(icon.className).not.toContain('wiggle-marker');
   window.appState.isInEditMode = false;
+});
+
+test('createLabelIcon includes size style', () => {
+  window.L.divIcon = jest.fn(opts => opts);
+  const icon = saveLocTest.createLabelIcon('A', '3', { lat: 0, lng: 0 });
+  expect(icon.html).toMatch(/style="width:\d+px;height:\d+px/);
 });
 
 test('applyRoadOrientation sets rotation transform', async () => {

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -71,3 +71,11 @@ test('createLabelIcon sanitizes label text', () => {
   expect(icon.html).toContain('Hi');
   expect(icon.html).not.toContain('<b>');
 });
+
+test('createLabelIcon adds wiggle class in edit mode', () => {
+  window.L.divIcon = jest.fn(opts => opts);
+  window.appState.isInEditMode = true;
+  const icon = saveLocTest.createLabelIcon('A', '2');
+  expect(icon.className).toContain('wiggle-marker');
+  window.appState.isInEditMode = false;
+});

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -80,3 +80,9 @@ test('createLabelIcon adds wiggle class in edit mode', () => {
   expect(icon.className).not.toContain('wiggle-marker');
   window.appState.isInEditMode = false;
 });
+
+test('applyRoadOrientation sets rotation transform', async () => {
+  const marker = { getLatLng: () => ({ lat: 0, lng: 0 }), _icon: { style: { transform: '' } } };
+  await saveLocTest.applyRoadOrientation(marker);
+  expect(marker._icon.style.transform).toContain('rotate(');
+});

--- a/tests/appFunctions.test.js
+++ b/tests/appFunctions.test.js
@@ -82,7 +82,11 @@ test('createLabelIcon adds wiggle class in edit mode', () => {
 });
 
 test('applyRoadOrientation sets rotation transform', async () => {
-  const marker = { getLatLng: () => ({ lat: 0, lng: 0 }), _icon: { style: { transform: '' } } };
+  const inner = document.createElement('div');
+  inner.className = 'custom-label-marker-inner';
+  const iconEl = document.createElement('div');
+  iconEl.appendChild(inner);
+  const marker = { getLatLng: () => ({ lat: 0, lng: 0 }), _icon: iconEl };
   await saveLocTest.applyRoadOrientation(marker);
-  expect(marker._icon.style.transform).toContain('rotate(');
+  expect(inner.style.getPropertyValue('--rotation')).toContain('deg');
 });


### PR DESCRIPTION
## Summary
- add wiggle animation CSS and class
- apply wiggle class to map markers when edit mode is enabled
- test that createLabelIcon adds the wiggle class in edit mode

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853bd71f72c832f9f2321aea61aa38f